### PR TITLE
Add ClearDisk - macOS menu bar cache cleanup utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Wanna support this curation? Feel free to <a href='https://ko-fi.com/B0B41QQ7L' 
 - [MonitorControl](https://github.com/MonitorControl/MonitorControl) Easily control the brightness of external Displays
 
 ### Memory/Files/App cleanup
+- [ClearDisk](https://github.com/bysiber/cleardisk) macOS menu bar utility that monitors 44+ developer cache paths (Xcode, Docker, npm, pip, Cargo, Homebrew, etc.) and helps reclaim disk space
 - [Pearcleaner](https://github.com/alienator88/Pearcleaner) free mac app cleaner inspired by Freemacsoft's AppCleaner
 - [Mole](https://github.com/tw93/Mole) Best terminal Free tool to reclaim space from your mac
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Wanna support this curation? Feel free to <a href='https://ko-fi.com/B0B41QQ7L' 
 - [MonitorControl](https://github.com/MonitorControl/MonitorControl) Easily control the brightness of external Displays
 
 ### Memory/Files/App cleanup
-- [ClearDisk](https://github.com/bysiber/cleardisk) macOS menu bar utility that monitors 44+ developer cache paths (Xcode, Docker, npm, pip, Cargo, Homebrew, etc.) and helps reclaim disk space
+- [ClearDisk](https://github.com/bysiber/cleardisk) macOS menu bar utility to clean developer cache paths (Xcode, Docker, npm, pip, Cargo, Homebrew, etc.) and reclaim disk space
 - [Pearcleaner](https://github.com/alienator88/Pearcleaner) free mac app cleaner inspired by Freemacsoft's AppCleaner
 - [Mole](https://github.com/tw93/Mole) Best terminal Free tool to reclaim space from your mac
 


### PR DESCRIPTION
## ClearDisk

A native macOS menu bar utility that monitors **44+ developer cache paths** and helps reclaim disk space with a single click.

### Key Features
- Lives in the menu bar — zero UI clutter
- Monitors Xcode DerivedData, CocoaPods, SPM, Docker, node_modules, pip, Cargo, Homebrew, Gradle, Go modules, and more
- One-click cleanup with safety confirmations
- Built with Swift / SwiftUI
- Free & Open Source

**GitHub:** https://github.com/bysiber/cleardisk
**Website:** https://cleardisk.app

Added under **Memory/Files/App cleanup** section.