### PR TITLE
Add Lockpaw to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Wanna support this curation? Feel free to <a href='https://ko-fi.com/B0B41QQ7L' 
 - [Lulu](https://github.com/objective-see/LuLu) Firewall for Mac Os
 - [NeoHtop](https://github.com/Abdenasser/neohtop) Task manager
 - [Mounty app + 3G NTFS Driver](https://mounty.app/) Enable write mode on NTFS external SSD/HDD
-- [Lockpaw](https://github.com/sorkila/lockpaw) Menu bar screen guard — lock/unlock your display with a hotkey
+- [Lockpaw](https://github.com/sorkila/lockpaw) Lock/unlock your display with a hotkey
 
 ### Monitoring
 - [Stats](https://github.com/exelban/stats) Monitor all your hardware from the Menu bar

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Wanna support this curation? Feel free to <a href='https://ko-fi.com/B0B41QQ7L' 
 - [Lulu](https://github.com/objective-see/LuLu) Firewall for Mac Os
 - [NeoHtop](https://github.com/Abdenasser/neohtop) Task manager
 - [Mounty app + 3G NTFS Driver](https://mounty.app/) Enable write mode on NTFS external SSD/HDD
+- [Lockpaw](https://github.com/sorkila/lockpaw) Menu bar screen guard — lock/unlock your display with a hotkey
 
 ### Monitoring
 - [Stats](https://github.com/exelban/stats) Monitor all your hardware from the Menu bar


### PR DESCRIPTION
[Lockpaw](https://github.com/sorkila/lockpaw) is an open-source macOS menu bar screen guard. Lock and unlock your display with a global hotkey. Built with Swift, MIT licensed, no telemetry.

- 47+ GitHub stars
- Available via Homebrew (`brew tap sorkila/lockpaw && brew install --cask lockpaw`)