### PR TITLE
Add RightLayout — AI keyboard layout fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Wanna support this curation? Feel free to <a href='https://ko-fi.com/B0B41QQ7L' 
 - [Lulu](https://github.com/objective-see/LuLu) Firewall for Mac Os
 - [NeoHtop](https://github.com/Abdenasser/neohtop) Task manager
 - [Mounty app + 3G NTFS Driver](https://mounty.app/) Enable write mode on NTFS external SSD/HDD
-- [RightLayout](https://github.com/chernistry/RightLayout) AI keyboard layout fixer — auto-corrects wrong keyboard layout (EN/RU/HE) as you type, local CoreML, no cloud
+- [RightLayout](https://github.com/chernistry/RightLayout) Auto-corrects wrong keyboard layout (EN/RU/HE) as you type.
 
 ### Monitoring
 - [Stats](https://github.com/exelban/stats) Monitor all your hardware from the Menu bar

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Wanna support this curation? Feel free to <a href='https://ko-fi.com/B0B41QQ7L' 
 - [Lulu](https://github.com/objective-see/LuLu) Firewall for Mac Os
 - [NeoHtop](https://github.com/Abdenasser/neohtop) Task manager
 - [Mounty app + 3G NTFS Driver](https://mounty.app/) Enable write mode on NTFS external SSD/HDD
+- [RightLayout](https://github.com/chernistry/RightLayout) AI keyboard layout fixer — auto-corrects wrong keyboard layout (EN/RU/HE) as you type, local CoreML, no cloud
 
 ### Monitoring
 - [Stats](https://github.com/exelban/stats) Monitor all your hardware from the Menu bar


### PR DESCRIPTION
## What

Adds [RightLayout](https://github.com/chernistry/RightLayout) to the **Utils** section.

RightLayout is an AI-powered keyboard layout fixer for macOS that auto-corrects wrong keyboard layout (EN/RU/HE) as you type. It runs locally via CoreML with no cloud dependency and learns your habits over time.

## Why this list

RightLayout fits the spirit of this curated list — it's a quality-of-life Mac utility that solves a real daily pain point for multilingual users.