### PR TITLE
Add Lockpaw (resubmission of #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Wanna support this curation? Feel free to <a href='https://ko-fi.com/B0B41QQ7L' 
 - [Lulu](https://github.com/objective-see/LuLu) Firewall for Mac Os
 - [NeoHtop](https://github.com/Abdenasser/neohtop) Task manager
 - [Mounty app + 3G NTFS Driver](https://mounty.app/) Enable write mode on NTFS external SSD/HDD
+- [Lockpaw](https://github.com/sorkila/lockpaw) Lock your screen with a hotkey without sleeping; glows when your AI agent needs you
 
 ### Monitoring
 - [Stats](https://github.com/exelban/stats) Monitor all your hardware from the Menu bar


### PR DESCRIPTION
This resubmits #3, which was auto-closed when I accidentally deleted the source fork during a cleanup — it wasn't rejected. Apologies for the noise!

[Lockpaw](https://getlockpaw.com) ([GitHub](https://github.com/sorkila/lockpaw)) is a macOS menu bar screen guard: lock/cover your screen with a hotkey without putting the Mac to sleep — input is blocked while builds and AI agents keep running, and the locked screen glows when your agent needs you. Touch ID unlock. Free, MIT-licensed, native Swift, no telemetry.