### PR TITLE
Add usage to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Wanna support this curation? Feel free to <a href='https://ko-fi.com/B0B41QQ7L' 
 
 ### Monitoring
 - [Stats](https://github.com/exelban/stats) Monitor all your hardware from the Menu bar
+- [usage](https://github.com/aqua5230/usage) Monitor Claude Code and Codex quota from the Menu bar (burn-rate predictions, offline HTML reports, zero API calls)
 
 ### Audio/Video tools
 - [Kap](https://github.com/wulkano/Kap) Screen recording tool (use it for quick gif making usually)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Wanna support this curation? Feel free to <a href='https://ko-fi.com/B0B41QQ7L' 
 
 ### Monitoring
 - [Stats](https://github.com/exelban/stats) Monitor all your hardware from the Menu bar
-- [usage](https://github.com/aqua5230/usage) Monitor Claude Code and Codex quota from the Menu bar (burn-rate predictions, offline HTML reports, zero API calls)
+- [Usage](https://github.com/aqua5230/usage) Monitor Claude Code and Codex quota from the Menu bar (burn-rate predictions, offline HTML reports, zero API calls)
 
 ### Audio/Video tools
 - [Kap](https://github.com/wulkano/Kap) Screen recording tool (use it for quick gif making usually)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Wanna support this curation? Feel free to <a href='https://ko-fi.com/B0B41QQ7L' 
 
 ### Monitoring
 - [Stats](https://github.com/exelban/stats) Monitor all your hardware from the Menu bar
-- [Usage](https://github.com/aqua5230/usage) Monitor Claude Code and Codex quota from the Menu bar (burn-rate predictions, offline HTML reports, zero API calls)
+- [Usage](https://github.com/aqua5230/usage) Monitor Claude Code, Codex and Antigravity quota from the Menu bar (burn-rate predictions, offline HTML reports, no LLM API calls)
 
 ### Audio/Video tools
 - [Kap](https://github.com/wulkano/Kap) Screen recording tool (use it for quick gif making usually)


### PR DESCRIPTION
Adds [usage](https://github.com/aqua5230/usage) — an open-source (AGPL-3.0) macOS menu bar app that pins Claude Code and Codex quota (5-hour / weekly) to the screen, with burn-rate predictions and offline HTML usage reports. It never calls the Anthropic/OpenAI API; all numbers come from local files, so monitoring adds zero token overhead. Installable via `brew install --cask aqua5230/usage/usage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)